### PR TITLE
Remove badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 # intrange
 
-[![Build Status](https://github.com/ckaznocha/intrange/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ckaznocha/intrange/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/ckaznocha/intrange/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/ckaznocha/intrange/actions/workflows/github-code-scanning/codeql)
 ![coverage](https://raw.githubusercontent.com/ckaznocha/intrange/badges/.badges/main/coverage.svg)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ckaznocha/intrange/badge)](https://scorecard.dev/viewer/?uri=github.com/ckaznocha/intrange)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10234/badge)](https://www.bestpractices.dev/projects/10234)
-[![License](https://img.shields.io/:license-mit-blue.svg)](https://ckaznocha.mit-license.org)
-[![Release](https://img.shields.io/github/release/ckaznocha/intrange.svg)](https://github.com/ckaznocha/intrange/releases/latest)
 [![GoDoc](https://godoc.org/github.com/ckaznocha/intrange?status.svg)](https://godoc.org/github.com/ckaznocha/intrange)
 
 intrange is a program for checking for loops that could use the [Go 1.22](https://go.dev/ref/spec#Go_1.22) integer


### PR DESCRIPTION
## Proposed Changes

- Remove badges on `README.md` that duplicate info easily found on the main repo page in github.
